### PR TITLE
fix: Downgrade mongodb-driver-reactivestreams to 5.5.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
+  ignore:
+    - dependency-name: "org.mongodb:mongodb-driver-reactivestreams" # version 5.6.0 breaks the build
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
 	// https://mvnrepository.com/artifact/org.mongodb/mongodb-driver-reactivestreams
-	implementation("org.mongodb:mongodb-driver-reactivestreams:5.6.0")
+	implementation("org.mongodb:mongodb-driver-reactivestreams:5.5.0")
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-security")


### PR DESCRIPTION
Downgraded `org.mongodb:mongodb-driver-reactivestreams` from 5.6.0 to 5.5.0 as version 5.6.0 causes build failures. Added an ignore rule for this dependency in Dependabot to prevent automatic updates to the problematic version.
